### PR TITLE
fix: align Docusaurus config with live domain uqucc-majors.sb.sa

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,11 @@
 1. قم بعمل Fork للمشروع إلى حسابك على GitHub
 2. قم بتنزيل النسخة المحلية باستخدام الأمر:
    ```
-   git clone https://github.com/YOUR-USERNAME/uqucis-majors.git
+   git clone https://github.com/YOUR-USERNAME/uqucc-majors.git
    ```
 3. قم بإضافة المستودع الأصلي كـ remote:
    ```
-   git remote add upstream https://github.com/Saad5400/uqucis-majors.git
+   git remote add upstream https://github.com/Saad5400/uqucc-majors.git
    ```
 4. قم بتثبيت التبعيات:
    ```

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
   favicon: 'img/favicon.png',
 
   // Set the production url of your site here
-  url: 'http://uqucis-majors.sb.sa',
+  url: 'https://uqucc-majors.sb.sa',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
@@ -19,7 +19,7 @@ const config: Config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'Saad5400', // Usually your GitHub org/user name.
-  projectName: 'uqucis-majors', // Usually your repo name.
+  projectName: 'uqucc-majors', // Usually your repo name.
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -114,7 +114,7 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
-          editUrl: 'https://github.com/Saad5400/uqucis-majors/tree/main/',
+          editUrl: 'https://github.com/Saad5400/uqucc-majors/tree/main/',
           routeBasePath: '/',
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
@@ -126,7 +126,7 @@ const config: Config = {
             xslt: true,
           },
           postsPerPage: 'ALL',
-          editUrl: 'https://github.com/Saad5400/uqucis-majors/tree/main/',
+          editUrl: 'https://github.com/Saad5400/uqucc-majors/tree/main/',
           onInlineTags: 'warn',
           onInlineAuthors: 'ignore',
           onUntruncatedBlogPosts: 'warn',


### PR DESCRIPTION
Replaces legacy uqucis-majors identifiers (url, projectName, both editUrls) with the current domain/repo, and fixes the stale clone/upstream URLs in CONTRIBUTING.md. Production build verified green (CNAME=uqucc-majors.sb.sa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)