### PR TITLE
Force dark mode by clearing stale light-mode localStorage preference

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -127,6 +127,11 @@ const config: Config = {
     },
   },
 
+  clientModules: [
+    // Clears stale light-mode preferences from localStorage and forces dark.
+    require.resolve('./src/clientModules/forceDarkMode.ts'),
+  ],
+
   plugins: [
     // Generates per-page dynamic Open Graph images (1200x630) + JSON-LD.
     require.resolve('./plugins/og-image'),

--- a/src/clientModules/forceDarkMode.ts
+++ b/src/clientModules/forceDarkMode.ts
@@ -1,0 +1,15 @@
+// We no longer support light ("bright") mode. The site is dark-only via the
+// `colorMode` config (defaultMode: 'dark', disableSwitch: true). However,
+// Docusaurus's color-mode init script still honors a `theme` value persisted
+// in localStorage, so returning users who once selected light mode stay stuck
+// on it. Wipe that stale preference and force the dark theme.
+if (typeof window !== 'undefined') {
+  try {
+    if (localStorage.getItem('theme') !== null) {
+      localStorage.removeItem('theme');
+    }
+  } catch {
+    // localStorage may be unavailable (private mode, blocked cookies); ignore.
+  }
+  document.documentElement.setAttribute('data-theme', 'dark');
+}


### PR DESCRIPTION
# وصف التغييرات
تم إضافة وحدة عميل جديدة لفرض الوضع الداكن على الموقع بمسح تفضيلات الوضع الفاتح القديمة المحفوظة في localStorage. الموقع الآن يدعم الوضع الداكن فقط عبر إعدادات Docusaurus، لكن المستخدمون العائدون الذين اختاروا الوضع الفاتح سابقاً قد يبقون عالقين فيه بسبب القيمة المحفوظة. هذا التغيير يحل المشكلة بمسح تلك التفضيلات القديمة وفرض الوضع الداكن.

## التخصص
- [x] هندسة البرمجيات

## قائمة المراجعة
- [x] قمت باختبار التغييرات
- [x] التغييرات لا تحتوي على أخطاء لغوية أو إملائية
- [x] التغييرات تتبع نفس أسلوب ونمط المحتوى الحالي

## التفاصيل التقنية
- **الملف الجديد**: `src/clientModules/forceDarkMode.ts` - وحدة عميل تعمل عند تحميل الصفحة
- **التعديل**: `docusaurus.config.ts` - تسجيل الوحدة الجديدة في مصفوفة `clientModules`

الكود يتعامل مع الحالات الاستثنائية (مثل الوضع الخاص في المتصفح) ويضمن عدم حدوث أخطاء إذا كان localStorage غير متاح.

## ملاحظات إضافية
التغيير بسيط وآمن - يعمل فقط على مسح بيانات قديمة وتعيين السمة المطلوبة. لا يؤثر على الوظائف الأخرى للموقع.

https://claude.ai/code/session_01YMXuPb39mEg9vzsEsxEF5t